### PR TITLE
Get the fallback asyncio.async via a different method, because

### DIFF
--- a/anthemav/connection.py
+++ b/anthemav/connection.py
@@ -8,7 +8,7 @@ __all__ = ('Connection')
 try:
     ensure_future = asyncio.ensure_future
 except:
-    ensure_future = asyncio.async
+    ensure_future =  getattr(asyncio, 'async')
 
 
 class Connection:


### PR DESCRIPTION
async is a reserved word in python3.7. Home Assistant just updated
to 3.7 and the anthemav plugin broke because of this line.

Using the method described at:
https://stackoverflow.com/questions/51196568/create-task-asyncio-async-syntaxerror-invalid-syntax