### PR TITLE
Support STR pre-amplifier and integrated amplifier

### DIFF
--- a/anthemav/protocol.py
+++ b/anthemav/protocol.py
@@ -762,7 +762,7 @@ class AVR(asyncio.Protocol):
             number_of_zones = 4
             # MDX 16 input number range is 1 to 12, but MDX 8 only have 1 to 4 and 9
             self._available_input_numbers = [1, 2, 3, 4, 9]
-        elif self._model_series == MODEL_STR_SEP or self._model_series == MODEL_STR_INT:
+        elif self._model_series in [MODEL_STR_SEP, MODEL_STR_INT]:
             number_of_zones = 1
         else:
             number_of_zones = 2
@@ -1314,7 +1314,7 @@ class Zone:
         if self.input_number > 0 and self._avr._model_series == MODEL_X40:
             return self._avr.values.get(f"IS{self.input_number}{command}")
         return None
-    
+
     def _get_float(self, key, default: float = 0.0) -> float:
         if key not in self.values:
             return default

--- a/anthemav/protocol.py
+++ b/anthemav/protocol.py
@@ -220,7 +220,8 @@ UNKNOWN_MODEL = "Unknown Model"
 MODEL_X40 = "x40"
 MODEL_X20 = "x20"
 MODEL_MDX = "mdx"
-MODEL_STR = "str"
+MODEL_STR_SEP = "str_pa"
+MODEL_STR_INT = "str_ia"
 
 
 # pylint: disable=too-many-instance-attributes, too-many-public-methods
@@ -454,7 +455,7 @@ class AVR(asyncio.Protocol):
         """
         total = total + 1
         for input_number in range(1, total):
-            if self._model_series == MODEL_STR:
+            if self._model_series == MODEL_STR_INT:
                 # Manually add HTB input
                 self._input_numbers["HTB"] = 32
                 self._input_names[32] = "HTB"
@@ -730,10 +731,17 @@ class AVR(asyncio.Protocol):
             self._ignored_commands = COMMANDS_X20 + COMMANDS_X40 + COMMANDS_MDX_IGNORE
             self._model_series = MODEL_MDX
             self.query("MAC")
-        elif "STR" in model:
-            self.log.debug("Set Command to Model STR")
+        elif "STR PA" in model:
+            self.log.debug("Set Command to Model STR Pre-Amp")
             self._ignored_commands = COMMANDS_STR_IGNORE
-            self._model_series = MODEL_STR
+            self._model_series = MODEL_STR_SEP
+            self._alm_number = ALM_NUMBER_STR
+            self._attenuation_range = [-96.0, 7.0]
+            self.query("IDN")
+        elif "STR IA" in model:
+            self.log.debug("Set Command to Model STR Integrated")
+            self._ignored_commands = COMMANDS_STR_IGNORE
+            self._model_series = MODEL_STR_INT
             self._alm_number = ALM_NUMBER_STR
             self._attenuation_range = [-96.0, 7.0]
             self.query("IDN")
@@ -754,7 +762,7 @@ class AVR(asyncio.Protocol):
             number_of_zones = 4
             # MDX 16 input number range is 1 to 12, but MDX 8 only have 1 to 4 and 9
             self._available_input_numbers = [1, 2, 3, 4, 9]
-        elif self._model_series == MODEL_STR:
+        elif self._model_series == MODEL_STR_SEP or self._model_series == MODEL_STR_INT:
             number_of_zones = 1
         else:
             number_of_zones = 2
@@ -1318,7 +1326,7 @@ class Zone:
     @property
     def support_attenuation(self) -> bool:
         """Return true if the zone support sound mode and sound mode list."""
-        return self._avr._model_series in [MODEL_X20, MODEL_STR]
+        return self._avr._model_series in [MODEL_X20, MODEL_STR_INT, MODEL_STR_SEP]
 
     #
     # Volume and Attenuation handlers.  The Anthem tracks volume internally as

--- a/anthemav/protocol.py
+++ b/anthemav/protocol.py
@@ -479,8 +479,6 @@ class AVR(asyncio.Protocol):
         recognized = False
         newdata = False
 
-        logging.info(f"Message:{data}")
-
         if data.startswith("!I"):
             self.log.warning("Invalid command: %s", data[2:])
             recognized = True

--- a/anthemav/protocol.py
+++ b/anthemav/protocol.py
@@ -394,7 +394,10 @@ class AVR(asyncio.Protocol):
         disassembles the chain of datagrams into individual messages which
         are then passed on for interpretation.
         """
-        self.transport.pause_reading()
+        try:
+            self.transport.pause_reading()
+        except AttributeError:
+            self.log.warning('Lost connection to receiver while assembling buffer')
 
         for message in self.buffer.split(";"):
             if message != "":
@@ -409,7 +412,10 @@ class AVR(asyncio.Protocol):
 
         self.buffer = ""
 
-        self.transport.resume_reading()
+        try:
+            self.transport.resume_reading()
+        except AttributeError:
+            self.log.warning('Lost connection to receiver while assembling buffer')
         return
 
     def _populate_inputs(self, total):

--- a/anthemav/protocol.py
+++ b/anthemav/protocol.py
@@ -47,10 +47,10 @@ ALM_NUMBER_x40 = {
 }
 
 ALM_NUMBER_STR = {
-    "Stereo": 0,
-    "Mono": 1,
-    "Both=Left": 2,
-    "Both=Right": 3,
+    "Stereo": 7,
+    "Mono": 9,
+    "Both=Left": 11,
+    "Both=Right": 12,
 }
 
 # Some models (eg:MRX 520) provide a limited list of listening mode


### PR DESCRIPTION
Addresses #38.

The STR pre-amplifier supports four listening modes: Stereo, Mono, Both left and Both right.

It only has one zone.

Minimum and maximum volume is -96.0dB and +7.0dB.  Volume can be set in 0.5dB increments.  This PR reworks `volume_to_attenuation()` and `attenuation_to_volume()` to handle this case, while preserving the -90dB to 0dB range of other devices.  Note that in doing so we change the type of `volume` from `int` to `float`.  Regression testing is advised.

The device supports Home Theatre Bypass mode AKA HTB, in which the output from a separate AV receiver can be connected to the pre-amplifier, which will pass through the signal to the connected power amplifier when the pre-amplifier is in standby mode.  HTB inputs are discussed in #38, however they are not able to be selected independently.  The official Anthem app does show them in the input list, but fails to switch to them.  They don't show up at all on the device front panel.  It is therefore probably not a bug that this library cannot select them.

Several commands which apply to AV receivers are not supported by the STR.  In particular, `BRT` is the read-only bitrate property on a receiver, but the read/write left/right channel balance adjust on the pre-amplifier.  The `Z1BRT0` commands adjusts balance to the right channel by 0.5dB, `Z1BRT50` adjusts by 2.5dB and `Z1BRT100` adjusts by 5dB (the maximum),  At startup most devices would receive `Z1BRT?` to query the current source bitrate, but the STR (probably incorrectly) interprets the command as `Z1BRT0`.  After instantiating the `AVR` class ten times, you would see your pre-amplifier shift the balance fully to the right.  We now avoid doing that by adding `BRT` to the list of commands which should *not* be sent at connection startup, as well as other commands which are not mentioned in the documentation from Anthem.