### PR TITLE
Remove asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-asyncio
+


### PR DESCRIPTION
`asyncio` is a Python [standard lib](https://docs.python.org/3/library/asyncio.html).